### PR TITLE
add new option to add re-export paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ ViteAliases({
 	useTypescript: false,
 
 	/**
+	 * Will generate paths in tsconfig for re-exporting modules from an index.ts file
+	 * Used in combination with `useConfig` and `useTypeScript`
+	 */
+	addReExportPaths: false,
+
+	/**
 	 * Root path of Vite project
 	 */
 	root: process.cwd()

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -8,7 +8,8 @@ const config = {
 			useConfig: true,
 			useTypescript: true,
 			allowLogging: true,
-			adjustDuplicates: true
+			adjustDuplicates: true,
+			addReExportPaths: false
 		}),
 	],
 	server: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const config: Required<Options> = {
 	useConfig: false,
 	useRelativePaths: false,
 	useTypescript: false,
+	addReExportPaths: false,
 
 	root: process.cwd(),
 };

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -92,7 +92,7 @@ export class Generator {
 				replacement: `${p}`
 			});
 
-			this.handleConfigPath(p, `${key}/*`);
+			this.handleConfigPath(p, key);
 		});
 	}
 
@@ -122,10 +122,14 @@ export class Generator {
 	 */
 
 	handleConfigPath(path: string, key ?:string) {
-		const p = this.options.useRelativePaths ? toRelative(path, this.options.dir) : slash(`${path}/*`);
+		const p = this.options.useRelativePaths ? toRelative(path, this.options.dir) : slash(path);
 
 		if(key) {
-			this.paths[key] = [p];
+			this.paths[`${key}/*`] = [`${p}/*`];
+
+			if(this.options.addReExportPaths) {
+				this.paths[key] = [p];
+			}
 		} else {
 			this.paths = Object.fromEntries(Object.entries(this.paths).filter((cp) => cp[1][0] === p));
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,13 @@ export interface Options {
 	useTypescript: boolean;
 
 	/**
+	 * Will generate paths in tsconfig for re-exporting modules from an index.ts file
+	 * Used in combination with `useConfig` and `useTypeScript`
+	 * @default false
+	 */
+	 addReExportPaths: boolean;
+
+	/**
 	 * Root path of Vite project
 	 * @default 'process.cwd()'
 	 */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function toArray<T>(value: T | T[]): T[] {
 export function toRelative(path: string, dir: string): string {
 	let folders = split(slash(path), '/');
 	folders = folders.slice(folders.findIndex((f) => f === dir), folders.length);
-	return slash(`./${folders.join('/')}/*`);
+	return slash(`./${folders.join('/')}`);
 }
 
 /**


### PR DESCRIPTION
Hi. 

Just found this plugin and it works great! Unfortunately I normally re-export modules from the index file of a directory. For that to work you need a alias pointing to the directory itself. I added a option called `addReExportPaths` to support the use case.


```ts
// tsconfig.json
{
  "compilerOptions": {
    ...
    "paths": {
      "@components/": ["./src/components/*"],
      // this will be added for every directory when addReExportPaths: true is passed
      "@components": ["./src/components"] 
    }
  },
}

```

Which will allow you to do this:

```ts
// ../components/index.ts
export { Button } from './Button'
export { Card } from './Card'

// ../some-feature/View.ts
import { Input, Card } from '@components'
```

Hope this looks alright. Would love your thoughts on this, or things that I might have missed.


Thanks!