### PR TITLE
feat(vite-aliases): Added Vite 3 Support + Export Default

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "@vite-aliases/example",
-    "description": "Example: Alias auto generation for Vite",
-    "version": "0.1.0",
-    "private": true,
-    "license": "MIT",
-    "author": "Subwaytime <leon.l@nophase.de>",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/subwaytime/vite-aliases"
-    },
-    "homepage": "https://github.com/subwaytime/vite-aliases#readme",
-    "bugs": "https://github.com/subwaytime/vite-aliases/issues",
-    "scripts": {
-        "update:packages": "npm update --save-dev && npm update --save",
-        "dev": "vite",
-        "build": "vite build"
-    },
-    "dependencies": {
-        "@vitejs/plugin-vue": "^2.3.3",
-        "@vue/compiler-sfc": "^3.2.37",
-        "vite": "^2.9.12",
-        "vitest": "^0.15.1",
-        "vue": "^3.2.37"
-    }
+	"name": "@vite-aliases/example",
+	"description": "Example: Alias auto generation for Vite",
+	"version": "0.1.0",
+	"private": true,
+	"license": "MIT",
+	"author": "Subwaytime <leon.l@nophase.de>",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/subwaytime/vite-aliases"
+	},
+	"homepage": "https://github.com/subwaytime/vite-aliases#readme",
+	"bugs": "https://github.com/subwaytime/vite-aliases/issues",
+	"scripts": {
+		"update:packages": "npm update --save-dev && npm update --save",
+		"dev": "vite",
+		"build": "vite build"
+	},
+	"dependencies": {
+		"@vitejs/plugin-vue": "^3.0.1",
+		"@vue/compiler-sfc": "^3.2.37",
+		"vite": "^3.0.5",
+		"vitest": "^0.21.1",
+		"vue": "^3.2.37"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
 	"name": "vite-aliases",
 	"description": "Alias auto generation for Vite",
 	"version": "0.9.2",
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
-			"import": "./dist/index.mjs",
+			"import": "./dist/index.cjs",
 			"types": "./dist/index.d.ts"
 		}
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,10 @@ export function ViteAliases(options?: Partial<Options>): Plugin {
 			gen.init();
 
 			config.resolve = {
-				alias: config.resolve?.alias ? [...config.resolve.alias as any, ...gen.aliases] : gen.aliases
+				alias: config.resolve?.alias ? [...(config.resolve.alias as any), ...gen.aliases] : gen.aliases,
 			};
-		}
-	}
+		},
+	};
 }
+
+export default ViteAliases;


### PR DESCRIPTION
# Vite 3 Support 

- Added Support for Vite 3. 
  - Turned to "type": "module"
  - Changed imports in `package.json` around to support new files 
- Added export default to `index.ts` -> to import as `import ViteAliases from '....'` or `import { ViteAliases }  from '...'`

If I need to change something or test with Vite 2, I can add those test. 

Thanks